### PR TITLE
Add support of swagger ui view for pyramid

### DIFF
--- a/hapic/ext/pyramid/context.py
+++ b/hapic/ext/pyramid/context.py
@@ -147,3 +147,31 @@ class PyramidContext(BaseContext):
 
     def by_pass_output_wrapping(self, response: typing.Any) -> bool:
         return False
+
+    def add_view(
+        self,
+        route: str,
+        http_method: str,
+        view_func: typing.Callable[..., typing.Any],
+    ) -> None:
+
+        self.configurator.add_route(
+            name=route,
+            path=route,
+            request_method='GET'
+        )
+
+        self.configurator.add_view(
+            view_func,
+            route_name=route,
+        )
+
+    def serve_directory(
+        self,
+        route_prefix: str,
+        directory_path: str,
+    ) -> None:
+        self.configurator.add_static_view(
+            name=route_prefix,
+            path=directory_path,
+        )

--- a/hapic/ext/pyramid/context.py
+++ b/hapic/ext/pyramid/context.py
@@ -158,7 +158,7 @@ class PyramidContext(BaseContext):
         self.configurator.add_route(
             name=route,
             path=route,
-            request_method='GET'
+            request_method=http_method
         )
 
         self.configurator.add_view(

--- a/hapic/hapic.py
+++ b/hapic/hapic.py
@@ -423,7 +423,15 @@ class Hapic(object):
             description=description,
         )
 
-        def spec_yaml_view( *args, **kwargs):
+        def spec_yaml_view(*args, **kwargs):
+            """
+            Method to return swagger generated yaml spec file.
+
+            This method will be call as a framework view, like those,
+            it need to handle the default arguments of a framework view.
+            As frameworks have different arguments patterns, we should
+            allow any arguments patterns (args, kwargs).
+            """
             return self.context.get_response(
                 doc_yaml,
                 mimetype='text/x-yaml',
@@ -441,13 +449,21 @@ class Hapic(object):
 
         # Declare the swaggerui view
         def api_doc_view(*args, **kwargs):
+            """
+            Method to return html index view of swagger ui.
+
+            This method will be call as a framework view, like those,
+            it need to handle the default arguments of a framework view.
+            As frameworks have different arguments patterns, we should
+            allow any arguments patterns (args, kwargs).
+            """
             return self.context.get_response(
                 doc_page_content,
                 http_code=HTTPStatus.OK,
                 mimetype='text/html',
             )
 
-        # Add a view to generate the html index page of swaggerui
+        # Add a view to generate the html index page of swagger-ui
         self.context.add_view(
             route=route,
             http_method='GET',

--- a/hapic/hapic.py
+++ b/hapic/hapic.py
@@ -409,15 +409,10 @@ class Hapic(object):
         if not route.endswith('/'):
             route = '{}/'.format(route)
 
-        # Add swagger directory as served static dir
         swaggerui_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             'static',
             'swaggerui',
-        )
-        self.context.serve_directory(
-            route,
-            swaggerui_path,
         )
 
         # Documentation file view
@@ -428,7 +423,7 @@ class Hapic(object):
             description=description,
         )
 
-        def spec_yaml_view():
+        def spec_yaml_view( *args, **kwargs):
             return self.context.get_response(
                 doc_yaml,
                 mimetype='text/x-yaml',
@@ -445,7 +440,7 @@ class Hapic(object):
         )
 
         # Declare the swaggerui view
-        def api_doc_view():
+        def api_doc_view(*args, **kwargs):
             return self.context.get_response(
                 doc_page_content,
                 http_code=HTTPStatus.OK,
@@ -464,4 +459,10 @@ class Hapic(object):
             route=os.path.join(route, 'spec.yml'),
             http_method='GET',
             view_func=spec_yaml_view,
+        )
+
+        # Add swagger directory as served static dir
+        self.context.serve_directory(
+            route,
+            swaggerui_path,
         )


### PR DESCRIPTION
Fix to add support for documentation view (swagger ui) in pyramid.
To avoid view trouble with pyramid, assets directory is serve at last. We should probably think about a better way to deal with this, but this code seems to work correctly with existent documentation view backend (pyramid and flask).