### PR TITLE
Use http_method params instead of default in 'add_view' (flask backend)

### DIFF
--- a/hapic/ext/flask/context.py
+++ b/hapic/ext/flask/context.py
@@ -133,6 +133,7 @@ class FlaskContext(BaseContext):
         view_func: typing.Callable[..., typing.Any],
     ) -> None:
         self.app.add_url_rule(
+            methods=[http_method],
             rule=route,
             view_func=view_func,
         )


### PR DESCRIPTION
Just a simple fix for flask backend. similar as cbf738d6dc0bb0e5c529bba8f3c5d08ed2846ad8 for pyramid.
Make http_method params used by "add_view" method.