### PR TITLE
WIP: better output_file support for hapic

### DIFF
--- a/example/example_a_pyramid.py
+++ b/example/example_a_pyramid.py
@@ -1,18 +1,26 @@
 # -*- coding: utf-8 -*-
 import json
+from io import BytesIO
+from wsgiref.simple_server import make_server
+
+import hapic
+from hapic.data import HapicData
+from hapic.data import HapicFile
+from hapic.ext.pyramid import PyramidContext
+from PIL import Image
+from pyramid.config import Configurator
+
+from example import HelloJsonSchema
+from example import HelloPathSchema
+from example import HelloQuerySchema
+from example import HelloResponseSchema
+
 try:  # Python 3.5+
     from http import HTTPStatus
 except ImportError:
     from http import client as HTTPStatus
 
-from pyramid.config import Configurator
-from wsgiref.simple_server import make_server
 
-import hapic
-from example import HelloResponseSchema, HelloPathSchema, HelloJsonSchema, \
-    ErrorResponseSchema, HelloQuerySchema
-from hapic.data import HapicData
-from hapic.ext.pyramid import PyramidContext
 
 
 def bob(f):
@@ -82,6 +90,44 @@ class Controllers(object):
             'name': name,
         }
 
+    @hapic.with_api_doc()
+    @hapic.output_file(['image/jpeg'])
+    def hellofile(self, context, request):
+        return HapicFile(
+             file_path='/home/guenael/Images/Mount_Ararat_and_the_Araratian_plain_(cropped).jpg',
+             mimetype='image/jpeg',
+             as_attachment=False,
+        )
+
+    @hapic.with_api_doc()
+    @hapic.output_file(['image/jpeg'])
+    def hellofile2(self, context, request):
+        file = BytesIO()
+        image = Image.new('RGBA', size=(1000, 1000), color=(0, 0, 0))
+        image.save(file, 'png')
+        file.name = 'test_image.png'
+        file.seek(0)
+        return HapicFile(
+             filename='coucou.png',
+             file_object=file,
+             mimetype='image/png'
+        )
+
+    @hapic.with_api_doc()
+    @hapic.output_file(['image/jpeg'])
+    def hellofile3(self, context, request):
+        file = BytesIO()
+        image = Image.new('RGBA', size=(1000, 1000), color=(0, 0, 0))
+        image.save(file, 'png')
+        file.name = 'test_image.png'
+        file.seek(0)
+        return HapicFile(
+             filename='coucou.png',
+             file_object=file,
+             mimetype='image/png',
+             as_attachment=True,
+        )
+
     def bind(self, configurator: Configurator):
         configurator.add_route('hello', '/hello/{name}', request_method='GET')
         configurator.add_view(self.hello, route_name='hello', renderer='json')
@@ -92,6 +138,14 @@ class Controllers(object):
         configurator.add_route('hello3', '/hello3/{name}', request_method='GET')  # nopep8
         configurator.add_view(self.hello3, route_name='hello3', renderer='json')  # nopep8
 
+        configurator.add_route('hellofile', '/hellofile', request_method='GET')  # nopep8
+        configurator.add_view(self.hellofile, route_name='hellofile')  # nopep8
+
+        configurator.add_route('hellofile2', '/hellofile2', request_method='GET')  # nopep8
+        configurator.add_view(self.hellofile2, route_name='hellofile2')  # nopep8
+
+        configurator.add_route('hellofile3', '/hellofile3', request_method='GET')  # nopep8
+        configurator.add_view(self.hellofile3, route_name='hellofile3')  # nopep8
 
 configurator = Configurator(autocommit=True)
 controllers = Controllers()

--- a/hapic/context.py
+++ b/hapic/context.py
@@ -2,6 +2,7 @@
 import json
 import typing
 
+from hapic.data import HapicFile
 from hapic.error import ErrorBuilderInterface
 
 try:  # Python 3.5+
@@ -38,6 +39,13 @@ class ContextInterface(object):
         response: str,
         http_code: int,
         mimetype: str='application/json',
+    ) -> typing.Any:
+        raise NotImplementedError()
+
+    def get_file_response(
+        self,
+        file_response: HapicFile,
+        http_code: int,
     ) -> typing.Any:
         raise NotImplementedError()
 

--- a/hapic/data.py
+++ b/hapic/data.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import typing
 
 
 class HapicData(object):
@@ -9,3 +10,27 @@ class HapicData(object):
         self.headers = {}
         self.forms = {}
         self.files = {}
+
+
+class HapicFile(object):
+    def __init__(
+        self,
+        file_path: typing.Optional[str] = None,
+        file_object: typing.Any = None,
+        mimetype: typing.Any = None,
+        filename: str = None,
+        as_attachment: bool = False,
+    ):
+        self.file_path = file_path
+        self.file_object = file_object
+        self.filename = filename
+        self.mimetype = mimetype
+        self.as_attachment = as_attachment
+
+    def get_content_disposition_header_value(self) -> str:
+        disposition = 'inline'
+        if self.as_attachment:
+            disposition = 'attachment'
+        if self.filename:
+            disposition = '{}; filename="{}"'.format(disposition, self.filename)
+        return disposition

--- a/hapic/hapic.py
+++ b/hapic/hapic.py
@@ -39,6 +39,7 @@ from hapic.description import OutputHeadersDescription
 from hapic.description import OutputFileDescription
 from hapic.doc import DocGenerator
 from hapic.processor import ProcessorInterface
+from hapic.processor import FileOutputProcessor
 from hapic.processor import MarshmallowInputProcessor
 from hapic.processor import MarshmallowInputFilesProcessor
 from hapic.processor import MarshmallowOutputProcessor
@@ -246,9 +247,15 @@ class Hapic(object):
     def output_file(
         self,
         output_types: typing.List[str],
+        processor: ProcessorInterface = None,
+        context: ContextInterface = None,
         default_http_code: HTTPStatus = HTTPStatus.OK,
     ) -> typing.Callable[[typing.Callable[..., typing.Any]], typing.Any]:
+        processor = processor or FileOutputProcessor()
+        context = context or self._context_getter
         decoration = OutputFileControllerWrapper(
+            context=context,
+            processor=processor,
             output_types=output_types,
             default_http_code=default_http_code,
         )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ tests_require = [
     'webtest',
     'aiohttp',
     'pytest-aiohttp',
+    'pillow'
 ]
 dev_require = [
     'requests',

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
+import os
+from io import BytesIO
+
 import marshmallow as marshmallow
 import pytest
+from PIL import Image
 
+from hapic.data import HapicFile
 from hapic.exception import OutputValidationException
 from hapic.processor import MarshmallowOutputProcessor
+from hapic.processor import FileOutputProcessor
 from hapic.processor import MarshmallowInputProcessor
 from tests.base import Base
 
@@ -14,6 +20,90 @@ class MySchema(marshmallow.Schema):
 
 
 class TestProcessor(Base):
+
+    def test_unit_file_output_processor_ok__process_success_filepath(self):
+        processor = FileOutputProcessor()
+
+        tested_data = HapicFile(
+            file_path=os.path.abspath(__file__)
+        )
+        data = processor.process(tested_data)
+        assert data == tested_data
+
+    def test_unit_file_output_processor_ok__process_success_fileobject(self):
+        processor = FileOutputProcessor()
+        file = BytesIO()
+        image = Image.new('RGBA', size=(1000, 1000), color=(0, 0, 0))
+        image.save(file, 'png')
+        file.name = 'test_image.png'
+        file.seek(0)
+        tested_data = HapicFile(
+            file_object=file,
+            mimetype='image/png',
+        )
+        data = processor.process(tested_data)
+        assert data == tested_data
+
+    def test_unit_file_output_processor_err__wrong_type(self):
+        processor = FileOutputProcessor()
+        file = BytesIO()
+        image = Image.new('RGBA', size=(1000, 1000), color=(0, 0, 0))
+        image.save(file, 'png')
+        file.name = 'test_image.png'
+        file.seek(0)
+        tested_data = None
+        with pytest.raises(OutputValidationException):
+            data = processor.process(tested_data)
+
+    def test_unit_file_output_processor_err__both_path_and_object(self):
+        processor = FileOutputProcessor()
+        file = BytesIO()
+        image = Image.new('RGBA', size=(1000, 1000), color=(0, 0, 0))
+        image.save(file, 'png')
+        file.name = 'test_image.png'
+        file.seek(0)
+        tested_data = HapicFile(
+            file_path=os.path.abspath(__file__),
+            file_object=file,
+            mimetype='image/png',
+        )
+        with pytest.raises(OutputValidationException):
+            data = processor.process(tested_data)
+
+    def test_unit_file_output_processor_err__no_path_no_object(self):
+        processor = FileOutputProcessor()
+        file = BytesIO()
+        image = Image.new('RGBA', size=(1000, 1000), color=(0, 0, 0))
+        image.save(file, 'png')
+        file.name = 'test_image.png'
+        file.seek(0)
+        tested_data = HapicFile(
+            mimetype='image/png',
+        )
+        with pytest.raises(OutputValidationException):
+            data = processor.process(tested_data)
+
+    def test_unit_file_output_processor_err__file_do_not_exist(self):
+        processor = FileOutputProcessor()
+        tested_data = HapicFile(
+            file_path='_____________'
+        )
+        with pytest.raises(OutputValidationException):
+            data = processor.process(tested_data)
+
+    def test_unit_file_output_processor_err__missing_mimetype_for_file_object(self):  # nopep8
+        processor = FileOutputProcessor()
+        file = BytesIO()
+        image = Image.new('RGBA', size=(1000, 1000), color=(0, 0, 0))
+        image.save(file, 'png')
+        file.name = 'test_image.png'
+        file.seek(0)
+        tested_data = HapicFile(
+            file_object=file
+        )
+        with pytest.raises(OutputValidationException):
+            data = processor.process(tested_data)
+
     def test_unit__marshmallow_output_processor__ok__process_success(self):
         processor = MarshmallowOutputProcessor()
         processor.schema = MySchema()


### PR DESCRIPTION
- Add HapicFile type to allow return file easily with hapic
- Setup output file wrapper to work with HapicFile content.
- Add Pyramid support for this new feature (get_file_response)
- Simple tests for file processor.
