### PR TITLE
fix: use a standard import instead of using __init__

### DIFF
--- a/hapic/processor/main.py
+++ b/hapic/processor/main.py
@@ -4,7 +4,7 @@ import os
 import typing
 
 from apispec import BasePlugin
-from multidict.__init__ import MultiDict
+from multidict import MultiDict
 
 from hapic.data import HapicFile
 from hapic.doc.schema import SchemaUsage


### PR DESCRIPTION
Using __init__ works with python directly but pyinstaller's
loading method do not handle it.