### PR TITLE
Fix broken example files

### DIFF
--- a/example/example_a_aiohttp.py
+++ b/example/example_a_aiohttp.py
@@ -6,8 +6,9 @@ from hapic import Hapic
 from hapic import HapicData
 from hapic.error.marshmallow import MarshmallowDefaultErrorBuilder
 from hapic.ext.aiohttp.context import AiohttpContext
+from hapic.processor.marshmallow import MarshmallowProcessor
 
-hapic = Hapic(async_=True)
+hapic = Hapic(async_=True, processor_class=MarshmallowProcessor)
 
 
 class DisplayNameInputPathSchema(marshmallow.Schema):
@@ -45,7 +46,7 @@ async def do_login(request):
     return web.json_response({"login": login})
 
 
-app = web.Application(debug=True)
+app = web.Application()
 app.add_routes(
     [
         web.get("/n/", display_name),

--- a/example/example_a_pyramid.py
+++ b/example/example_a_pyramid.py
@@ -6,10 +6,10 @@ from wsgiref.simple_server import make_server
 from PIL import Image
 from pyramid.config import Configurator
 
-from example import HelloJsonSchema
-from example import HelloPathSchema
-from example import HelloQuerySchema
-from example import HelloResponseSchema
+from example.example import HelloJsonSchema
+from example.example import HelloPathSchema
+from example.example import HelloQuerySchema
+from example.example import HelloResponseSchema
 import hapic
 from hapic.data import HapicData
 from hapic.data import HapicFile


### PR DESCRIPTION
- example_a_aiohttp.py: Add MarshmallowProcessor import and configure it in Hapic constructor (was causing ConfigurationException)
- example_a_pyramid.py: Fix import paths from 'example' to 'example.example' (was causing ImportError)
- example_a_aiohttp.py: Remove deprecated debug=True parameter from web.Application()

Both examples now load and run successfully.